### PR TITLE
[Component Library] Table components

### DIFF
--- a/lib/components/button.ml
+++ b/lib/components/button.ml
@@ -1,5 +1,3 @@
-[@@@ocaml.warning "-27"]
-
 open Tyxml.Html
 
 type children = Html_types.button_content_fun elt list_wrap
@@ -103,8 +101,7 @@ let make
   ?(attributes = [])
   ?(variant = Primary)
   ?(size = Medium)
-  ~children
-  ()
+  children
   =
   let classes' = classes @ classes_of_props ~variant ~size in
   let attrs = attributes @ [ a_class classes' ] in

--- a/lib/components/button.mli
+++ b/lib/components/button.mli
@@ -22,6 +22,5 @@ val make
   -> ?attributes:Html_types.button_attrib Tyxml_html.attrib list
   -> ?variant:variant
   -> ?size:size
-  -> children:children
-  -> unit
+  -> children
   -> Html_types.button elt

--- a/lib/components/dune
+++ b/lib/components/dune
@@ -1,3 +1,3 @@
 (library
   (name components)
-  (libraries  base fmt tyxml hx))
+  (libraries  base stdio fmt tyxml hx))

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -78,25 +78,6 @@ module Data_cell = struct
   ;;
 end
 
-let wrapper_classes =
-  [ "h-full"
-  ; "w-full"
-  ; "overflow-auto"
-  ; "rounded-xl"
-  ; "border"
-  ; "border-black/5"
-  ; "bg-slate-100"
-  ; "py-8"
-  ; "text-slate-500"
-  ; "shadow-sm"
-  ; "dark:border-white/5"
-  ; "dark:bg-slate-900/40"
-  ; "dark:text-slate-400"
-  ]
-;;
-
-let table_classes = [ "border-collapse"; "w-full"; "h-full"; "text-sm" ]
-
 type variant =
   | Fixed
   | Responsive
@@ -113,7 +94,28 @@ let variant_is_unstyled = function
   | _ -> false
 ;;
 
-let table_wrapper = div ~a:[ a_class wrapper_classes ]
+let base_classes = [ "border-collapse"; "w-full"; "h-full"; "text-sm" ]
+
+let table_wrapper =
+  div
+    ~a:
+      [ a_class
+          [ "h-full"
+          ; "w-full"
+          ; "overflow-auto"
+          ; "rounded-xl"
+          ; "border"
+          ; "border-black/5"
+          ; "bg-slate-100"
+          ; "py-8"
+          ; "text-slate-500"
+          ; "shadow-sm"
+          ; "dark:border-white/5"
+          ; "dark:bg-slate-900/40"
+          ; "dark:text-slate-400"
+          ]
+      ]
+;;
 
 let make ?(classes = []) ?(attributes = []) ?(variant = Responsive) children =
   if variant_is_unstyled variant
@@ -123,7 +125,7 @@ let make ?(classes = []) ?(attributes = []) ?(variant = Responsive) children =
   else
     table_wrapper
       [ tablex
-          ~a:[ a_class (table_classes @ classes_of_variant variant) ]
+          ~a:[ a_class (base_classes @ classes_of_variant variant) ]
           children
       ]
 ;;

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -18,7 +18,10 @@ module Body = struct
   let base_classes = [ "bg-slate-50"; "dark:bg-slate-800" ]
 
   let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class (base_classes @ classes) ] in
+    let merged_classes =
+      List.concat [ base_classes; classes ] |> a_class |> List.return
+    in
+    let attrs = attributes @ merged_classes in
     tbody ~a:attrs children
   ;;
 end
@@ -45,7 +48,10 @@ module Row = struct
     children
     =
     let hover_classes' = classes_of_hover_style hover_style in
-    let attrs = attributes @ [ a_class (classes @ hover_classes') ] in
+    let merged_classes =
+      List.concat [ classes; hover_classes' ] |> a_class |> List.return
+    in
+    let attrs = attributes @ merged_classes in
     tr ~a:attrs children
   ;;
 end
@@ -68,7 +74,10 @@ module Header_cell = struct
   ;;
 
   let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class (classes @ base_classes) ] in
+    let merged_classes =
+      List.concat [ base_classes; classes ] |> a_class |> List.return
+    in
+    let attrs = attributes @ merged_classes in
     th ~a:attrs children
   ;;
 end
@@ -88,7 +97,10 @@ module Data_cell = struct
   ;;
 
   let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class (classes @ base_classes) ] in
+    let merged_classes =
+      List.concat [ base_classes; classes ] |> a_class |> List.return
+    in
+    let attrs = attributes @ merged_classes in
     td ~a:attrs children
   ;;
 end
@@ -131,7 +143,13 @@ let make
   =
   if variant_is_unstyled variant
   then tablex ~a:(attributes @ [ a_class classes ]) ?thead ?tfoot children
-  else
+  else (
+    let merged_classes =
+      [ base_classes; classes_of_variant variant; classes ]
+      |> List.concat
+      |> a_class
+      |> List.return
+    in
     div
       ~a:
         [ a_class
@@ -150,12 +168,5 @@ let make
             ; "dark:text-slate-400"
             ]
         ]
-      [ tablex
-          ~a:
-            (attributes
-             @ [ a_class (base_classes @ classes_of_variant variant @ classes) ]
-            )
-          ?thead
-          children
-      ]
+      [ tablex ~a:(attributes @ merged_classes) ?thead children ])
 ;;

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -38,7 +38,73 @@ module Data_cell = struct
   ;;
 end
 
-module Column_spec = struct
+let wrapper_classes =
+  [ "h-full"
+  ; "w-full"
+  ; "overflow-auto"
+  ; "rounded-xl"
+  ; "border"
+  ; "border-black/5"
+  ; "bg-slate-100"
+  ; "py-8"
+  ; "text-slate-500"
+  ; "shadow-sm"
+  ; "dark:border-white/5"
+  ; "dark:bg-slate-900/40"
+  ; "dark:text-slate-400"
+  ]
+;;
+
+let table_classes = [ "border-collapse"; "w-full"; "h-full"; "text-sm" ]
+
+module Responsive = struct
+  let make children =
+    let wrapper = div ~a:[ a_class wrapper_classes ] in
+    wrapper
+      [ tablex ~a:[ a_class (table_classes @ [ "table-auto" ]) ] children ]
+  ;;
+end
+
+module Fixed = struct
+  let make children =
+    let wrapper = div ~a:[ a_class wrapper_classes ] in
+    wrapper
+      [ tablex ~a:[ a_class (table_classes @ [ "table-fixed" ]) ] children ]
+  ;;
+end
+
+module Element = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    table ~a:attrs children
+  ;;
+end
+
+(* let make
+   (type data)
+   ~(columns : (data, 'a) Column_spec.t list)
+   ~(data : data list)
+   ()
+   =
+   let thead =
+   columns
+   |> List.map ~f:Column_spec.to_header_cell
+   |> Row.make
+   |> List.return
+   |> Head.make
+   in
+   let tbody =
+   data
+   |> List.map ~f:(fun datum ->
+   columns |> List.map ~f:(Column_spec.to_data_cell datum))
+   |> List.map ~f:Row.make
+   |> Body.make
+   |> List.return
+   in
+   tablex ~a:[ a_class [ table_classes ] ] ~thead tbody
+   ;; *)
+
+(* module Column_spec = struct
   type ('data, 'column) t =
     { header : string
     ; accessor : 'data -> 'column
@@ -61,63 +127,4 @@ module Column_spec = struct
     |> List.return
     |> Data_cell.make
   ;;
-end
-
-module Responsive_table = struct
-  let make
-    (type data)
-    ~(columns : (data, 'a) Column_spec.t list)
-    ~(data : data list)
-    ()
-    =
-    let thead =
-      columns
-      |> List.map ~f:Column_spec.to_header_cell
-      |> Row.make
-      |> List.return
-      |> Head.make
-    in
-    let tbody =
-      data
-      |> List.map ~f:(fun datum ->
-        columns |> List.map ~f:(Column_spec.to_data_cell datum))
-      |> List.map ~f:Row.make
-      |> Body.make
-      |> List.return
-    in
-    tablex ~thead tbody
-  ;;
-end
-
-module Fixed = struct
-  let make
-    (type data)
-    ~(columns : (data, 'a) Column_spec.t list)
-    ~(data : data list)
-    ()
-    =
-    let thead =
-      columns
-      |> List.map ~f:Column_spec.to_header_cell
-      |> Row.make
-      |> List.return
-      |> Head.make
-    in
-    let tbody =
-      data
-      |> List.map ~f:(fun datum ->
-        columns |> List.map ~f:(Column_spec.to_data_cell datum))
-      |> List.map ~f:Row.make
-      |> Body.make
-      |> List.return
-    in
-    tablex ~thead tbody
-  ;;
-end
-
-module Element = struct
-  let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class classes ] in
-    table ~a:attrs children
-  ;;
-end
+end *)

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -97,28 +97,36 @@ let wrapper_classes =
 
 let table_classes = [ "border-collapse"; "w-full"; "h-full"; "text-sm" ]
 
-module Responsive = struct
-  let make children =
-    let wrapper = div ~a:[ a_class wrapper_classes ] in
-    wrapper
-      [ tablex ~a:[ a_class (table_classes @ [ "table-auto" ]) ] children ]
-  ;;
-end
+type variant =
+  | Fixed
+  | Responsive
+  | Unstyled
 
-module Fixed = struct
-  let make children =
-    let wrapper = div ~a:[ a_class wrapper_classes ] in
-    wrapper
-      [ tablex ~a:[ a_class (table_classes @ [ "table-fixed" ]) ] children ]
-  ;;
-end
+let classes_of_variant = function
+  | Unstyled -> []
+  | Fixed -> [ "table-fixed" ]
+  | Responsive -> [ "table-auto" ]
+;;
 
-module Element = struct
-  let make ?(classes = []) ?(attributes = []) children =
+let variant_is_unstyled = function
+  | Unstyled -> true
+  | _ -> false
+;;
+
+let table_wrapper = div ~a:[ a_class wrapper_classes ]
+
+let make ?(classes = []) ?(attributes = []) ?(variant = Responsive) children =
+  if variant_is_unstyled variant
+  then (
     let attrs = attributes @ [ a_class classes ] in
-    table ~a:attrs children
-  ;;
-end
+    tablex ~a:attrs children)
+  else
+    table_wrapper
+      [ tablex
+          ~a:[ a_class (table_classes @ classes_of_variant variant) ]
+          children
+      ]
+;;
 
 (* let make
    (type data)

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -18,22 +18,62 @@ module Body = struct
 end
 
 module Row = struct
-  let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class classes ] in
+  let hover_classes = [ "dark:hover:bg-slate-700"; "hover:bg-slate-50" ]
+
+  type hover_style =
+    | Highlight
+    | None
+
+  let classes_of_hover_style = function
+    | Highlight -> hover_classes
+    | None -> []
+  ;;
+
+  let make
+    ?(classes = [])
+    ?(attributes = [])
+    ?(hover_style = Highlight)
+    children
+    =
+    let hover_classes' = classes_of_hover_style hover_style in
+    let attrs = attributes @ [ a_class (classes @ hover_classes') ] in
     tr ~a:attrs children
   ;;
 end
 
 module Header_cell = struct
+  let base_classes =
+    [ "border-b"
+    ; "p-4"
+    ; "pb-3"
+    ; "first:pl-8"
+    ; "last:pr-8"
+    ; "pt-0"
+    ; "text-left"
+    ; "font-medium"
+    ; "dark:border-slate-600"
+    ]
+  ;;
+
   let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class classes ] in
+    let attrs = attributes @ [ a_class (classes @ base_classes) ] in
     th ~a:attrs children
   ;;
 end
 
 module Data_cell = struct
+  let base_classes =
+    [ "border-b"
+    ; "border-slate-100"
+    ; "p-4"
+    ; "first:pl-8"
+    ; "last:pr-8"
+    ; "dark:border-slate-700"
+    ]
+  ;;
+
   let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class classes ] in
+    let attrs = attributes @ [ a_class (classes @ base_classes) ] in
     td ~a:attrs children
   ;;
 end

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -1,0 +1,123 @@
+[@@@ocaml.warning "-26-27-34"]
+
+open Base
+open Tyxml.Html
+
+module Head = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    thead ~a:attrs children
+  ;;
+end
+
+module Body = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    tbody ~a:attrs children
+  ;;
+end
+
+module Row = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    tr ~a:attrs children
+  ;;
+end
+
+module Header_cell = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    th ~a:attrs children
+  ;;
+end
+
+module Data_cell = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    td ~a:attrs children
+  ;;
+end
+
+module Column_spec = struct
+  type ('data, 'column) t =
+    { header : string
+    ; accessor : 'data -> 'column
+    ; to_string : 'column -> string
+    }
+
+  let header { header; _ } = header
+  let accessor { accessor; _ } = accessor
+  let value { accessor; _ } data = accessor data
+
+  let to_header_cell column =
+    column.header |> txt |> List.return |> Header_cell.make
+  ;;
+
+  let to_data_cell datum column =
+    datum
+    |> column.accessor
+    |> column.to_string
+    |> txt
+    |> List.return
+    |> Data_cell.make
+  ;;
+end
+
+module Responsive_table = struct
+  let make
+    (type data)
+    ~(columns : (data, 'a) Column_spec.t list)
+    ~(data : data list)
+    ()
+    =
+    let thead =
+      columns
+      |> List.map ~f:Column_spec.to_header_cell
+      |> Row.make
+      |> List.return
+      |> Head.make
+    in
+    let tbody =
+      data
+      |> List.map ~f:(fun datum ->
+        columns |> List.map ~f:(Column_spec.to_data_cell datum))
+      |> List.map ~f:Row.make
+      |> Body.make
+      |> List.return
+    in
+    tablex ~thead tbody
+  ;;
+end
+
+module Fixed = struct
+  let make
+    (type data)
+    ~(columns : (data, 'a) Column_spec.t list)
+    ~(data : data list)
+    ()
+    =
+    let thead =
+      columns
+      |> List.map ~f:Column_spec.to_header_cell
+      |> Row.make
+      |> List.return
+      |> Head.make
+    in
+    let tbody =
+      data
+      |> List.map ~f:(fun datum ->
+        columns |> List.map ~f:(Column_spec.to_data_cell datum))
+      |> List.map ~f:Row.make
+      |> Body.make
+      |> List.return
+    in
+    tablex ~thead tbody
+  ;;
+end
+
+module Element = struct
+  let make ?(classes = []) ?(attributes = []) children =
+    let attrs = attributes @ [ a_class classes ] in
+    table ~a:attrs children
+  ;;
+end

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -125,7 +125,7 @@ let make ?(classes = []) ?(attributes = []) ?(variant = Responsive) children =
       [ tablex
           ~a:
             (attributes
-             @ [ a_class (classes @ base_classes @ classes_of_variant variant) ]
+             @ [ a_class (base_classes @ classes_of_variant variant @ classes) ]
             )
           children
       ]

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -119,13 +119,14 @@ let table_wrapper =
 
 let make ?(classes = []) ?(attributes = []) ?(variant = Responsive) children =
   if variant_is_unstyled variant
-  then (
-    let attrs = attributes @ [ a_class classes ] in
-    tablex ~a:attrs children)
+  then tablex ~a:(attributes @ [ a_class classes ]) children
   else
     table_wrapper
       [ tablex
-          ~a:[ a_class (base_classes @ classes_of_variant variant) ]
+          ~a:
+            (attributes
+             @ [ a_class (classes @ base_classes @ classes_of_variant variant) ]
+            )
           children
       ]
 ;;

--- a/lib/components/table.mli
+++ b/lib/components/table.mli
@@ -1,0 +1,94 @@
+open Base
+open Tyxml.Html
+
+module Head : sig
+  type attributes = Html_types.thead_attrib Tyxml_html.attrib list
+  type children = Html_types.thead_content_fun elt list_wrap
+
+  val make
+    :  ?classes:string list
+    -> ?attributes:attributes
+    -> children
+    -> Html_types.thead elt
+end
+
+module Body : sig
+  type attributes = Html_types.tbody_attrib Tyxml_html.attrib list
+  type children = Html_types.tbody_content_fun elt list_wrap
+
+  val make
+    :  ?classes:string list
+    -> ?attributes:attributes
+    -> children
+    -> Html_types.tbody elt
+end
+
+module Row : sig
+  type attributes = Html_types.tr_attrib Tyxml_html.attrib list
+  type children = Html_types.tr_content_fun elt list_wrap
+
+  type hover_style =
+    | Highlight
+    | None
+
+  (** Constructs a table row using the provided [children].
+      - [classes] is an optional list of CSS classes to style the row.
+      - [attributes] is an optional list of button-specific attributes for elements within the row.
+      - The row's hover behavior is determined by [hover_style]:
+        * [Highlight]: (default) The row gets highlighted on hover.
+        * [None]: No hover effect.
+
+      Additional custom styling can be provided via [classes] and specific HTML attributes via [attributes]. *)
+  val make
+    :  ?classes:string list
+    -> ?attributes:attributes
+    -> ?hover_style:hover_style
+    -> children
+    -> Html_types.tr elt
+end
+
+module Header_cell : sig
+  type attributes = Html_types.thead_attrib Tyxml_html.attrib list
+  type children = Html_types.th_content_fun elt list_wrap
+
+  val make
+    :  ?classes:string list
+    -> ?attributes:attributes
+    -> Html_types.th_content_fun elt list_wrap
+    -> Html_types.th elt
+end
+
+module Data_cell : sig
+  type attributes = Html_types.td_attrib Tyxml_html.attrib list
+  type children = Html_types.td_content_fun elt list_wrap
+
+  val make
+    :  ?classes:string list
+    -> ?attributes:attributes
+    -> children
+    -> Html_types.td elt
+end
+
+type attributes = Html_types.tablex_attrib Tyxml_html.attrib list
+type children = Html_types.tablex_content_fun elt list_wrap
+
+type variant =
+  | Fixed
+  | Responsive
+  | Unstyled
+
+(** Constructs a table using the provided [children].
+    - [thead] and [tfoot] are optional table headers and footers, respectively.
+    - The table appearance is determined by the [variant]:
+      * [Unstyled]: The table is rendered without any specific styling.
+      * [Fixed] or [Responsive]: The table adapts to these styles, but [tfoot] is ignored in these cases.
+
+    Additional custom styling can be provided via [classes] and HTML attributes via [attributes]. *)
+val make
+  :  ?classes:string list
+  -> ?attributes:attributes
+  -> ?variant:variant
+  -> ?thead:Html_types.thead elt
+  -> ?tfoot:Html_types.tfoot elt
+  -> children
+  -> [> `Div | `Table ] elt

--- a/lib/components/typography.ml
+++ b/lib/components/typography.ml
@@ -85,8 +85,7 @@ let make
   ?(size : size = Medium)
   ?(font_style = Sans)
   ?(font_weight = Normal)
-  ~children
-  ()
+  children
   =
   let classes' = classes @ classes_of_props ~size ~font_style ~font_weight in
   let attrs = attributes @ [ a_class classes' ] in

--- a/lib/components/typography.mli
+++ b/lib/components/typography.mli
@@ -39,6 +39,5 @@ val make
   -> ?size:size
   -> ?font_style:font_style
   -> ?font_weight:font_weight
-  -> children:children
-  -> unit
+  -> children
   -> [ `H1 | `H2 | `H3 | `H4 | `H5 | `H6 | `P ] Tyxml_html.elt

--- a/lib/components/util.ml
+++ b/lib/components/util.ml
@@ -1,0 +1,2 @@
+let html_to_string html = Fmt.str "%a" (Tyxml.Html.pp ()) html
+let elt_to_string elt = Fmt.str "%a" (Tyxml.Html.pp_elt ()) elt


### PR DESCRIPTION
# [Component Library] Table components
- Adds the following components to the library:
  -  `Table` with `Fixed`, `Responsive`, and `Unstyled` variants
  -  `Table.Head`
  -  `Table.Body`
  -  `Table.Row`
  -  `Table.Header_cell`
  -  `Table.Data_cell`
  
  ## Screenshots
### Table (Light mode)
![image](https://github.com/tjdevries/thereactagen/assets/2755722/bef18342-bd27-488d-8253-2411d1e28abc)

  ### Table (Dark Mode)
![image](https://github.com/tjdevries/thereactagen/assets/2755722/065644e9-df42-4151-abc5-16cfd227b073)
