### PR TITLE
[Component Library] Remove attributes + classes arguments in favor of TyXML a parameter

### DIFF
--- a/lib/components/button.ml
+++ b/lib/components/button.ml
@@ -1,6 +1,7 @@
 open Tyxml.Html
 
 type children = Html_types.button_content_fun elt list_wrap
+type attributes = Html_types.button_attrib Tyxml_html.attrib list
 
 type size =
   | Small
@@ -96,14 +97,7 @@ let classes_of_props ~variant ~size =
     [ base_classes; classes_of_variant variant; classes_of_size size ]
 ;;
 
-let make
-  ?(classes = [])
-  ?(attributes = [])
-  ?(variant = Primary)
-  ?(size = Medium)
-  children
-  =
-  let classes' = classes @ classes_of_props ~variant ~size in
-  let attrs = attributes @ [ a_class classes' ] in
-  button ~a:attrs children
+let make ?(a = []) ?(variant = Primary) ?(size = Medium) children =
+  let attrbutes = a @ [ a_class (classes_of_props ~variant ~size) ] in
+  button ~a:attrbutes children
 ;;

--- a/lib/components/button.mli
+++ b/lib/components/button.mli
@@ -1,6 +1,7 @@
 open Tyxml.Html
 
 type children = Html_types.button_content_fun elt list_wrap
+type attributes = Html_types.button_attrib Tyxml_html.attrib list
 
 type size =
   | Small
@@ -18,8 +19,7 @@ type variant =
   | Twitch
 
 val make
-  :  ?classes:string list
-  -> ?attributes:Html_types.button_attrib Tyxml_html.attrib list
+  :  ?a:attributes
   -> ?variant:variant
   -> ?size:size
   -> children

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -5,10 +5,7 @@ module Head = struct
   type attributes = Html_types.thead_attrib Tyxml_html.attrib list
   type children = Html_types.thead_content_fun elt list_wrap
 
-  let make ?(classes = []) ?(attributes = []) children =
-    let attrs = attributes @ [ a_class classes ] in
-    thead ~a:attrs children
-  ;;
+  let make ?(a = []) children = thead ~a children
 end
 
 module Body = struct
@@ -17,12 +14,9 @@ module Body = struct
 
   let base_classes = [ "bg-slate-50"; "dark:bg-slate-800" ]
 
-  let make ?(classes = []) ?(attributes = []) children =
-    let merged_classes =
-      List.concat [ base_classes; classes ] |> a_class |> List.return
-    in
-    let attrs = attributes @ merged_classes in
-    tbody ~a:attrs children
+  let make ?(a = []) children =
+    let attributes = a @ [ a_class base_classes ] in
+    tbody ~a:attributes children
   ;;
 end
 
@@ -41,18 +35,9 @@ module Row = struct
     | None -> []
   ;;
 
-  let make
-    ?(classes = [])
-    ?(attributes = [])
-    ?(hover_style = Highlight)
-    children
-    =
-    let hover_classes' = classes_of_hover_style hover_style in
-    let merged_classes =
-      List.concat [ classes; hover_classes' ] |> a_class |> List.return
-    in
-    let attrs = attributes @ merged_classes in
-    tr ~a:attrs children
+  let make ?(a = []) ?(hover_style = Highlight) children =
+    let attributes = a @ [ hover_style |> classes_of_hover_style |> a_class ] in
+    tr ~a:attributes children
   ;;
 end
 
@@ -73,12 +58,9 @@ module Header_cell = struct
     ]
   ;;
 
-  let make ?(classes = []) ?(attributes = []) children =
-    let merged_classes =
-      List.concat [ base_classes; classes ] |> a_class |> List.return
-    in
-    let attrs = attributes @ merged_classes in
-    th ~a:attrs children
+  let make ?(a = []) children =
+    let attributes = a @ [ a_class base_classes ] in
+    th ~a:attributes children
   ;;
 end
 
@@ -96,12 +78,9 @@ module Data_cell = struct
     ]
   ;;
 
-  let make ?(classes = []) ?(attributes = []) children =
-    let merged_classes =
-      List.concat [ base_classes; classes ] |> a_class |> List.return
-    in
-    let attrs = attributes @ merged_classes in
-    td ~a:attrs children
+  let make ?(a = []) children =
+    let attributes = a @ [ a_class base_classes ] in
+    td ~a:attributes children
   ;;
 end
 
@@ -133,19 +112,12 @@ let base_classes = [ "border-collapse"; "w-full"; "h-full"; "text-sm" ]
       * [Fixed] or [Responsive]: The table adapts to these styles, but [tfoot] is ignored in these cases.
 
     Additional custom styling can be provided via [classes] and HTML attributes via [attributes]. *)
-let make
-  ?(classes = [])
-  ?(attributes = [])
-  ?(variant = Responsive)
-  ?thead
-  ?tfoot
-  children
-  =
+let make ?(a = []) ?(variant = Responsive) ?thead ?tfoot children =
   if variant_is_unstyled variant
-  then tablex ~a:(attributes @ [ a_class classes ]) ?thead ?tfoot children
+  then tablex ~a ?thead ?tfoot children
   else (
     let merged_classes =
-      [ base_classes; classes_of_variant variant; classes ]
+      [ base_classes; classes_of_variant variant ]
       |> List.concat
       |> a_class
       |> List.return
@@ -168,5 +140,5 @@ let make
             ; "dark:text-slate-400"
             ]
         ]
-      [ tablex ~a:(attributes @ merged_classes) ?thead children ])
+      [ tablex ~a:(a @ merged_classes) ?thead children ])
 ;;

--- a/lib/components/table.mli
+++ b/lib/components/table.mli
@@ -5,22 +5,14 @@ module Head : sig
   type attributes = Html_types.thead_attrib Tyxml_html.attrib list
   type children = Html_types.thead_content_fun elt list_wrap
 
-  val make
-    :  ?classes:string list
-    -> ?attributes:attributes
-    -> children
-    -> Html_types.thead elt
+  val make : ?a:attributes -> children -> Html_types.thead elt
 end
 
 module Body : sig
   type attributes = Html_types.tbody_attrib Tyxml_html.attrib list
   type children = Html_types.tbody_content_fun elt list_wrap
 
-  val make
-    :  ?classes:string list
-    -> ?attributes:attributes
-    -> children
-    -> Html_types.tbody elt
+  val make : ?a:attributes -> children -> Html_types.tbody elt
 end
 
 module Row : sig
@@ -40,8 +32,7 @@ module Row : sig
 
       Additional custom styling can be provided via [classes] and specific HTML attributes via [attributes]. *)
   val make
-    :  ?classes:string list
-    -> ?attributes:attributes
+    :  ?a:attributes
     -> ?hover_style:hover_style
     -> children
     -> Html_types.tr elt
@@ -52,8 +43,7 @@ module Header_cell : sig
   type children = Html_types.th_content_fun elt list_wrap
 
   val make
-    :  ?classes:string list
-    -> ?attributes:attributes
+    :  ?a:attributes
     -> Html_types.th_content_fun elt list_wrap
     -> Html_types.th elt
 end
@@ -62,11 +52,7 @@ module Data_cell : sig
   type attributes = Html_types.td_attrib Tyxml_html.attrib list
   type children = Html_types.td_content_fun elt list_wrap
 
-  val make
-    :  ?classes:string list
-    -> ?attributes:attributes
-    -> children
-    -> Html_types.td elt
+  val make : ?a:attributes -> children -> Html_types.td elt
 end
 
 type attributes = Html_types.tablex_attrib Tyxml_html.attrib list
@@ -85,8 +71,7 @@ type variant =
 
     Additional custom styling can be provided via [classes] and HTML attributes via [attributes]. *)
 val make
-  :  ?classes:string list
-  -> ?attributes:attributes
+  :  ?a:attributes
   -> ?variant:variant
   -> ?thead:Html_types.thead elt
   -> ?tfoot:Html_types.tfoot elt

--- a/lib/components/typography.ml
+++ b/lib/components/typography.ml
@@ -1,6 +1,7 @@
 open Tyxml.Html
 
 type children = Html_types.phrasing Tyxml_html.elt list_wrap
+type attributes = Html_types.common Tyxml_html.attrib list
 
 type elt =
   | H1
@@ -79,16 +80,15 @@ let elt_of_props elt =
 ;;
 
 let make
-  ?(classes = [])
-  ?(attributes = [])
+  ?(a = [])
   ?(as_elt = P)
   ?(size : size = Medium)
   ?(font_style = Sans)
   ?(font_weight = Normal)
   children
   =
-  let classes' = classes @ classes_of_props ~size ~font_style ~font_weight in
-  let attrs = attributes @ [ a_class classes' ] in
+  let classes = classes_of_props ~size ~font_style ~font_weight in
+  let attributes = a @ [ a_class classes ] in
   let elt = elt_of_props as_elt in
-  elt ~a:attrs children
+  elt ~a:attributes children
 ;;

--- a/lib/components/typography.mli
+++ b/lib/components/typography.mli
@@ -1,6 +1,7 @@
 open Tyxml.Html
 
 type children = Html_types.phrasing Tyxml_html.elt list_wrap
+type attributes = Html_types.common Tyxml_html.attrib list
 
 type elt =
   | H1
@@ -33,8 +34,7 @@ type font_weight =
   | Black
 
 val make
-  :  ?classes:string list
-  -> ?attributes:Html_types.common Tyxml_html.attrib list
+  :  ?a:attributes
   -> ?as_elt:elt
   -> ?size:size
   -> ?font_style:font_style


### PR DESCRIPTION
# [Component Library] Remove attributes + classes arguments in favor of TyXML a parameter
- Refactors existing components to use `~a` rather than a combination of `~attributes` and `~classes` to have a better consistency with TyXML