### PR TITLE
[Component Library] Add merge_attributes_list util, add Card component

### DIFF
--- a/lib/components/button.ml
+++ b/lib/components/button.ml
@@ -98,6 +98,8 @@ let classes_of_props ~variant ~size =
 ;;
 
 let make ?(a = []) ?(variant = Primary) ?(size = Medium) children =
-  let attrbutes = a @ [ a_class (classes_of_props ~variant ~size) ] in
-  button ~a:attrbutes children
+  let attributes =
+    Util.merge_attribute_list [ "class", classes_of_props ~variant ~size ] a
+  in
+  button ~a:attributes children
 ;;

--- a/lib/components/card.ml
+++ b/lib/components/card.ml
@@ -1,0 +1,21 @@
+open Tyxml.Html
+
+type attributes = Html_types.div_attrib Tyxml_html.attrib list
+type children = Html_types.div_content_fun elt list_wrap
+
+let base_classes =
+  [ "p-6"
+  ; "rounded-xl"
+  ; "bg-white"
+  ; "dark:bg-slate-800"
+  ; "shadow-xl"
+  ; "border"
+  ; "border-slate-200/60"
+  ; "dark:border-slate-700/20"
+  ]
+;;
+
+let make ?(a = []) children =
+  let attributes = Util.merge_attribute_list [ "class", base_classes ] a in
+  div ~a:attributes children
+;;

--- a/lib/components/card.mli
+++ b/lib/components/card.mli
@@ -1,0 +1,6 @@
+open Tyxml.Html
+
+type attributes = Html_types.div_attrib Tyxml_html.attrib list
+type children = Html_types.div_content_fun elt list_wrap
+
+val make : ?a:attributes -> children -> Html_types.div elt

--- a/lib/components/dune
+++ b/lib/components/dune
@@ -1,3 +1,3 @@
 (library
   (name components)
-  (libraries  base stdio fmt tyxml hx))
+  (libraries base stdio fmt tyxml hx))

--- a/lib/components/table.ml
+++ b/lib/components/table.ml
@@ -15,7 +15,7 @@ module Body = struct
   let base_classes = [ "bg-slate-50"; "dark:bg-slate-800" ]
 
   let make ?(a = []) children =
-    let attributes = a @ [ a_class base_classes ] in
+    let attributes = Util.merge_attribute_list [ "class", base_classes ] a in
     tbody ~a:attributes children
   ;;
 end
@@ -36,7 +36,11 @@ module Row = struct
   ;;
 
   let make ?(a = []) ?(hover_style = Highlight) children =
-    let attributes = a @ [ hover_style |> classes_of_hover_style |> a_class ] in
+    let attributes =
+      Util.merge_attribute_list
+        [ "class", classes_of_hover_style hover_style ]
+        a
+    in
     tr ~a:attributes children
   ;;
 end
@@ -79,7 +83,7 @@ module Data_cell = struct
   ;;
 
   let make ?(a = []) children =
-    let attributes = a @ [ a_class base_classes ] in
+    let attributes = Util.merge_attribute_list [ "class", base_classes ] a in
     td ~a:attributes children
   ;;
 end
@@ -117,11 +121,9 @@ let make ?(a = []) ?(variant = Responsive) ?thead ?tfoot children =
   then tablex ~a ?thead ?tfoot children
   else (
     let merged_classes =
-      [ base_classes; classes_of_variant variant ]
-      |> List.concat
-      |> a_class
-      |> List.return
+      [ base_classes; classes_of_variant variant ] |> List.concat
     in
+    let attributes = Util.merge_attribute_list [ "class", merged_classes ] a in
     div
       ~a:
         [ a_class
@@ -140,5 +142,5 @@ let make ?(a = []) ?(variant = Responsive) ?thead ?tfoot children =
             ; "dark:text-slate-400"
             ]
         ]
-      [ tablex ~a:(a @ merged_classes) ?thead children ])
+      [ tablex ~a:attributes ?thead children ])
 ;;

--- a/lib/components/typography.ml
+++ b/lib/components/typography.ml
@@ -88,7 +88,7 @@ let make
   children
   =
   let classes = classes_of_props ~size ~font_style ~font_weight in
-  let attributes = a @ [ a_class classes ] in
+  let attributes = Util.merge_attribute_list [ "class", classes ] a in
   let elt = elt_of_props as_elt in
   elt ~a:attributes children
 ;;

--- a/lib/components/typography.mli
+++ b/lib/components/typography.mli
@@ -40,4 +40,4 @@ val make
   -> ?font_style:font_style
   -> ?font_weight:font_weight
   -> children
-  -> [ `H1 | `H2 | `H3 | `H4 | `H5 | `H6 | `P ] Tyxml_html.elt
+  -> [> `H1 | `H2 | `H3 | `H4 | `H5 | `H6 | `P ] Tyxml_html.elt

--- a/lib/components/util.ml
+++ b/lib/components/util.ml
@@ -1,2 +1,18 @@
+open Base
+
 let html_to_string html = Fmt.str "%a" (Tyxml.Html.pp ()) html
 let elt_to_string elt = Fmt.str "%a" (Tyxml.Html.pp_elt ()) elt
+
+(** Processes and merges multiple attribute name and value pairs into a provided attribute list.
+    - [attribute_pairs] consists of a list of tuples, where each tuple represents an attribute name and its corresponding list of values to be merged.
+    - [attributes] is the list of existing attributes that will be updated or appended with new ones from [attribute_pairs].
+
+    Each tuple in [attribute_pairs] will undergo the same merge or insertion process as defined in [merge_attribute_values]. *)
+let merge_attribute_list attribute_pairs attributes =
+  attribute_pairs
+  |> List.fold
+       ~init:(Tyxml.Html.to_xmlattribs attributes)
+       ~f:(fun acc (name, values) ->
+         Tyxml.Xml.add_string_attrib name (String.concat ~sep:" " values) acc)
+  |> List.map ~f:Tyxml.Html.to_attrib
+;;


### PR DESCRIPTION
# [Component Library] Add merge_attributes_list util, add Card component
- Adds a utility fn `merge_attributes_list` to safely merge `TyXML.attrib`'s
- Adds a `Card` component as a basic surface component
- Refactors existing components to use merge util